### PR TITLE
changed IFDEF LEAF_APPENDS to constexpr;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ scripts/workloads/
 results/
 *.csv
 .vscode/c_cpp_properties.json
+*.cache/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,17 @@
         "mutex": "cpp"
     },
     "C_Cpp.clang_format_fallbackStyle": "Google",
-    "clang-format.fallbackStyle": "Google"
+    "clang-format.fallbackStyle": "Google",
+    "editor.defaultFormatter": "ms-vscode.cpptools",
+    "files.associations": {
+        "any": "cpp",
+        "bitset": "cpp",
+        "memory": "cpp",
+        "random": "cpp",
+        "future": "cpp",
+        "optional": "cpp"
+    },
+    "[cpp]": {
+        "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
+    }
 }

--- a/src/tree_analysis.cpp
+++ b/src/tree_analysis.cpp
@@ -32,7 +32,11 @@ using namespace ConcurrentQuITBTree;
 using namespace SimpleBTree;  // FOR_SIMPLEBTREE or fallback
 #endif
 
+#if defined(FOR_CONCURRENT_QUIT_APPENDS)
+using tree_t = BTree<key_type, value_type, true>;
+#else
 using tree_t = BTree<key_type, value_type>;
+#endif
 
 std::vector<key_type> read_txt(const char *filename) {
     std::vector<key_type> data;
@@ -160,7 +164,7 @@ class Workload {
         }
     }
 
-    void run_all(std::vector<std::vector<key_type>> &data) {
+    void run_all(std::vector<std::vector<key_type> > &data) {
         for (size_t j = 0; j < conf.repeat; ++j) {
             for (size_t k = 0; k < data.size(); ++k) {
                 run(conf.files[k], data[k]);
@@ -329,7 +333,7 @@ int main(int argc, char **argv) {
 
     std::cout << "Writing results to: " << conf.results_csv << std::endl;
 
-    std::vector<std::vector<key_type>> data;
+    std::vector<std::vector<key_type> > data;
     for (const auto &file : conf.files) {
         std::filesystem::path fsPath(file);
         std::cout << "Reading " << fsPath.filename().c_str() << std::endl;


### PR DESCRIPTION
Attempts to move away from IFDEFs in code for the BTree and instead uses a template argument evaluated using constexpr. 

**we still use `#ifdef LEAF_APPENDS` to enable leaf appends in `tree_analysis.cpp`.** - to be changed in a future PR. 